### PR TITLE
allow non-dependence on puppetlabs-apache

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,7 +1,8 @@
 class git::server(
   $site_name = '',
   $ssh_key,
-  $vhost     = ''
+  $vhost     = '',
+  $apache_conf = ''
 ) {
   include stdlib
   
@@ -17,6 +18,7 @@ class git::server(
     site_name => $REAL_site_name,
     ssh_key   => $ssh_key,
     vhost     => $REAL_vhost,
+    apache_conf => $apache_conf,
   }
   -> anchor { 'git::server::end': }
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,7 +1,8 @@
 class git::server::config(
   $site_name,
   $ssh_key,
-  $vhost
+  $vhost = '',
+  $apache_conf = ''
 ) { 
   File {
     owner => $git::params::gt_uid,
@@ -48,13 +49,20 @@ class git::server::config(
     ensure => file,
     source => 'puppet:///modules/git/gitweb.js',
   }
-  apache::vhost { $vhost:
-    port     => '80',
-    docroot  => $git::params::gt_repo_dir,
-    ssl      => 'false',
-    template => 'git/gitweb-apache-vhost.conf.erb',
-    priority => '99',
-    require  => [ File["/etc/gitweb.conf"], File["${git::params::gt_httpd_conf_dir}/git.conf"] ],
+
+  if $apache_conf == '' {
+    apache::vhost { $vhost:
+      port     => '80',
+      docroot  => $git::params::gt_repo_dir,
+      ssl      => 'false',
+      template => 'git/gitweb-apache-vhost.conf.erb',
+      priority => '99',
+      require  => [ File["/etc/gitweb.conf"], File["${git::params::gt_httpd_conf_dir}/git.conf"] ],
+    }
+  } else {
+    file { $apache_conf:
+      content => template('git/gitweb-apache-vhost.conf.erb'),
+    }
   }
 
   # Gitolite Configuration


### PR DESCRIPTION
If apache_conf is passed as a parameter to git::server, it will
interpret the value as a filename in which to generate the apache
configuration.

This is useful if you don't use puppetlabs-apache to manage your apache
configuration.
