### PR TITLE
Change module name from git to gitolite

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,7 @@ _Apache Module_
 
 *Setup the initial Gitolite Admin keys and bootstrap* 
 <pre>
-   class { 'git':
+   class { 'gitolite':
     server    => 'true',
     site_name => 'Frymanet.com Git Repository',
     ssh_key   => 'ssh-rsa AAAA....',
@@ -27,7 +27,7 @@ _Apache Module_
 
 *Setup the initial Gitolite Admin keys and bootstrap using an external apache module* 
 <pre>
-   class { 'git':
+   class { 'gitolite':
     server               => 'true',
     site_name            => 'Frymanet.com Git Repository',
     ssh_key              => 'ssh-rsa AAAA....',
@@ -39,7 +39,7 @@ _Apache Module_
 
 *Setup the initial Gitolite Admin keys and bootstrap, but don't manage apache*
 <pre> 
-   class { 'git':
+   class { 'gitolite':
     server               => 'true',
     manage_apache        => 'false',
     site_name            => 'Frymanet.com Git Repository',
@@ -49,5 +49,5 @@ _Apache Module_
 
 *Only install Git Client Binaries*
 <pre>
- class { 'git': }
+ class { 'gitolite': }
 </pre>

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,4 +1,4 @@
-# Class: git::client
+# Class: gitolite::client
 #
 # This module manages git client management
 #
@@ -13,10 +13,10 @@
 # Sample Usage:
 #
 # This class file is not called directly.
-class git::client {
+class gitolite::client {
   include stdlib
 
-  anchor { 'git::client::begin': }
-  -> class { 'git::client::package': }
-  -> anchor { 'git::client::end': }
+  anchor { 'gitolite::client::begin': }
+  -> class { 'gitolite::client::package': }
+  -> anchor { 'gitolite::client::end': }
 }

--- a/manifests/client/package.pp
+++ b/manifests/client/package.pp
@@ -1,4 +1,4 @@
-# Class: git::client::package
+# Class: gitolite::client::package
 #
 # Description
 #  This class is designed to install Git client packages
@@ -14,8 +14,8 @@
 #
 # Sample Usage:
 #   This method should not be called directly.
-class git::client::package {
-  package { $git::params::gt_client_package:
+class gitolite::client::package {
+  package { $gitolite::params::gt_client_package:
     ensure => 'present',
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# Class: git
+# Class: gitolite
 #
 # Description
 #  This module is designed to configure and install git clients
@@ -10,16 +10,16 @@
 #  $server: Whether to install gitolite in addition to git core tools.
 #  $site_name: (default: "fqdn Git Repository") The friendly name displayed on
 #               the GitWeb main page.
-#  $manage_apache: flag to determine whether git module also manages Apache
+#  $manage_apache: flag to determine whether gitolite module also manages Apache
 #                  configuration
 #  $write_apache_conf_to: (file path). This option is used when you want to
-#                         contain apache configuration within the git class,
+#                         contain apache configuration within the gitolite class,
 #                         but do not want to use the puppetlabs-apache module
 #                         to manage apache. This option takes a file path
 #                         and will write the apache template to a specific file
 #                         on the filesystem.
 #                         REQUIRES: $apache_notify
-#  $apache_notify: Reference notification to be used if the git module will
+#  $apache_notify: Reference notification to be used if the gitolite module will
 #                  manage apache, but the puppetlabs-apache module is not
 #                  going to be used. This takes a type reference (e.g.:
 #                  Class['apache::service'] or Service['apache2']) to send a
@@ -46,7 +46,7 @@
 # Sample Usage:
 #
 #  Manage Apache:
-#   class { 'git':
+#   class { 'gitolite':
 #    server    => 'true',
 #    site_name => 'Frymanet.com Git Repository',
 #    ssh_key   => 'ssh-rsa AAAA....',
@@ -54,7 +54,7 @@
 #  }
 #
 #  Use and External Apache Module:
-#   class { 'git':
+#   class { 'gitolite':
 #    server               => 'true',
 #    site_name            => 'Frymanet.com Git Repository',
 #    ssh_key              => 'ssh-rsa AAAA....',
@@ -64,7 +64,7 @@
 #  }
 #
 #  Do not manage Apache:
-#   class { 'git':
+#   class { 'gitolite':
 #    server               => 'true',
 #    manage_apache        => 'false',
 #    site_name            => 'Frymanet.com Git Repository',
@@ -72,8 +72,8 @@
 #  }
 #
 #  Only install Git Client Binaries:
-#   class { 'git': }
-class git(
+#   class { 'gitolite': }
+class gitolite(
   $server               = false,
   $site_name            = '',
   $vhost                = '',
@@ -83,23 +83,23 @@ class git(
   $ssh_key              = ''
 ) {
   include stdlib
-  include git::params
+  include gitolite::params
 
-  anchor { 'git::begin': }
-  -> class  { 'git::client': }
-  -> anchor { 'git::end': }
+  anchor { 'gitolite::begin': }
+  -> class  { 'gitolite::client': }
+  -> anchor { 'gitolite::end': }
 
   if $server == true {
 
-    class { 'git::server':
+    class { 'gitolite::server':
       site_name            => $site_name,
       vhost                => $vhost,
       manage_apache        => $manage_apache,
       apache_notify        => $apache_notify,
       write_apache_conf_to => $write_apache_conf_to,
       ssh_key              => $ssh_key,
-      require              => Class['git::client'],
-      before               => Anchor['git::end'],
+      require              => Class['gitolite::client'],
+      before               => Anchor['gitolite::end'],
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,8 @@
-# Class: git::params
+# Class: gitolite::params
 #
 # Description
 #   This class is designed to carry default parameters for
-#   Class: git.
+#   Class: gitolite.
 #
 # Parameters:
 #  $gt_uid: username under the context where gitolite will run
@@ -28,7 +28,7 @@
 #
 # Sample Usage:
 #   This method should not be called directly.
-class git::params {
+class gitolite::params {
   $gt_uid       = 'gitolite'
   $gt_gid       = 'gitolite'
   $gt_repo_base = '/opt/git'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,4 +1,4 @@
-# Class: git::server
+# Class: gitolite::server
 #
 # This module manages git server management
 #
@@ -6,16 +6,16 @@
 #  $server: Whether to install gitolite in addition to git core tools.
 #  $site_name: (default: "fqdn Git Repository") The friendly name displayed on
 #               the GitWeb main page.
-#  $manage_apache: flag to determine whether git module also manages Apache
+#  $manage_apache: flag to determine whether gitolite module also manages Apache
 #                  configuration
 #  $write_apache_conf_to: (file path). This option is used when you want to
-#                         contain apache configuration within the git class,
+#                         contain apache configuration within the gitolite class,
 #                         but do not want to use the puppetlabs-apache module
 #                         to manage apache. This option takes a file path
 #                         and will write the apache template to a specific
 #                         file on the filesystem.
 #                         REQUIRES: $apache_notify
-#  $apache_notify: Reference notification to be used if the git module will
+#  $apache_notify: Reference notification to be used if the gitolite module will
 #                  manage apache, but the puppetlabs-apache module is not going
 #                  to be used. This takes a type reference (e.g.:
 #                  Class['apache::service'] or Service['apache2']) to send a
@@ -42,14 +42,14 @@
 # Sample Usage:
 #
 #  Manage Apache:
-#   class { 'git::server':
+#   class { 'gitolite::server':
 #    site_name => 'Frymanet.com Git Repository',
 #    ssh_key   => 'ssh-rsa AAAA....',
 #    vhost     => 'git.frymanet.com',
 #  }
 #
 #  Use and External Apache Module:
-#   class { 'git::server':
+#   class { 'gitolite::server':
 #    site_name            => 'Frymanet.com Git Repository',
 #    ssh_key              => 'ssh-rsa AAAA....',
 #    vhost                => 'git.frymanet.com',
@@ -58,13 +58,13 @@
 #  }
 #
 #  Do not manage Apache:
-#   class { 'git::server':
+#   class { 'gitolite::server':
 #    manage_apache        => 'false',
 #    site_name            => 'Frymanet.com Git Repository',
 #    ssh_key              => 'ssh-rsa AAAA....',
 #  }
 #
-class git::server(
+class gitolite::server(
   $ssh_key,
   $site_name            = '',
   $vhost                = '',
@@ -74,15 +74,15 @@ class git::server(
 ) {
   include stdlib
 
-  if $site_name == '' { $REAL_site_name = $git::params::gt_site_name }
+  if $site_name == '' { $REAL_site_name = $gitolite::params::gt_site_name }
   else { $REAL_site_name = $site_name }
 
-  if $vhost == '' { $REAL_vhost = $git::params::gt_vhost }
+  if $vhost == '' { $REAL_vhost = $gitolite::params::gt_vhost }
   else { $REAL_vhost = $vhost }
 
-  anchor { 'git::server::begin': }
-  -> class { 'git::server::package': }
-  -> class { 'git::server::config':
+  anchor { 'gitolite::server::begin': }
+  -> class { 'gitolite::server::package': }
+  -> class { 'gitolite::server::config':
     site_name            => $REAL_site_name,
     ssh_key              => $ssh_key,
     vhost                => $REAL_vhost,
@@ -90,5 +90,5 @@ class git::server(
     apache_notify        => $apache_notify,
     write_apache_conf_to => $write_apache_conf_to,
   }
-  -> anchor { 'git::server::end': }
+  -> anchor { 'gitolite::server::end': }
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,4 +1,4 @@
-# Class: git::server::config
+# Class: gitolite::server::config
 #
 # Description
 #  This class is designed to configure the system to use Gitolite and Gitweb
@@ -7,16 +7,16 @@
 #  $server: Whether to install gitolite in addition to git core tools.
 #  $site_name: (default: "fqdn Git Repository") The friendly name displayed on
 #              the GitWeb main page.
-#  $manage_apache: flag to determine whether git module also manages Apache
+#  $manage_apache: flag to determine whether gitolite module also manages Apache
 #                  configuration
 #  $write_apache_conf_to: (file path). This option is used when you want to
-#                         contain apache configuration within the git class,
-#                         but do not want to use the puppetlabs-apache module
-#                         to manage apache. This option takes a file path
-#                         and will write the apache template to a specific
+#                         contain apache configuration within the gitolite
+#                         class, but do not want to use the puppetlabs-apache
+#                         module to manage apache. This option takes a file
+#                         path and will write the apache template to a specific
 #                         file on the filesystem.
 #                         REQUIRES: $apache_notify
-#  $apache_notify: Reference notification to be used if the git module will
+#  $apache_notify: Reference notification to be used if the gitolite module will
 #                  manage apache, but the puppetlabs-apache module is not
 #                  going to be used. This takes a type reference (e.g.:
 #                  Class['apache::service'] or Service['apache2']) to send
@@ -33,7 +33,7 @@
 #
 # Sample Usage:
 #  This module should not be called directly.
-class git::server::config(
+class gitolite::server::config(
   $site_name,
   $ssh_key,
   $vhost,
@@ -42,58 +42,58 @@ class git::server::config(
   $write_apache_conf_to
 ) {
   File {
-    owner => $git::params::gt_uid,
-    group => $git::params::gt_gid,
+    owner => $gitolite::params::gt_uid,
+    group => $gitolite::params::gt_gid,
     mode  => '0644',
   }
   Exec {
     path => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin:/usr/local/sbin',
   }
 
-  # Gitolite User Setup
-  user { $git::params::gt_uid:
+  # gitolite User Setup
+  user { $gitolite::params::gt_uid:
     ensure  => 'present',
-    home    => $git::params::gt_repo_base,
-    gid     => $git::params::gt_gid,
+    home    => $gitolite::params::gt_repo_base,
+    gid     => $gitolite::params::gt_gid,
     comment => 'git repository hosting',
   }
-  group { $git::params::gt_gid:
+  group { $gitolite::params::gt_gid:
     ensure  => 'present',
-    members => $git::params::gt_httpd_uid,
+    members => $gitolite::params::gt_httpd_uid,
   }
   # Git Filesystem Repository Setup
-  file { $git::params::gt_repo_base:
+  file { $gitolite::params::gt_repo_base:
     ensure => 'directory',
   }
-  file { $git::params::gt_repo_dir:
+  file { $gitolite::params::gt_repo_dir:
     ensure  => 'directory',
   }
-  file { "${git::params::gt_httpd_conf_dir}/git.conf":
+  file { "${gitolite::params::gt_httpd_conf_dir}/git.conf":
     ensure => 'absent',
   }
 
   # Gitweb Setup
   file { '/etc/gitweb.conf':
     ensure  => file,
-    content => template('git/gitweb.conf.erb'),
+    content => template('gitolite/gitweb.conf.erb'),
   }
   ## add pretty style sheets
-  file { "${git::params::gt_gitweb_root}${git::params::gt_gitweb_spath}":
+  file { "${gitolite::params::gt_gitweb_root}${gitolite::params::gt_gitweb_spath}":
     ensure => directory,
   }
   file {
-    "${git::params::gt_gitweb_root}${git::params::gt_gitweb_spath}gitweb.css":
+    "${gitolite::params::gt_gitweb_root}${gitolite::params::gt_gitweb_spath}gitweb.css":
     ensure  => file,
-    source  => 'puppet:///modules/git/gitweb.css',
+    source  => 'puppet:///modules/gitolite/gitweb.css',
     require =>
-      File["${git::params::gt_gitweb_root}${git::params::gt_gitweb_spath}"],
+      File["${gitolite::params::gt_gitweb_root}${gitolite::params::gt_gitweb_spath}"],
   }
   file {
-    "${git::params::gt_gitweb_root}${git::params::gt_gitweb_spath}gitweb.js":
+    "${gitolite::params::gt_gitweb_root}${gitolite::params::gt_gitweb_spath}gitweb.js":
     ensure  => file,
-    source  => 'puppet:///modules/git/gitweb.js',
+    source  => 'puppet:///modules/gitolite/gitweb.js',
     require =>
-      File["${git::params::gt_gitweb_root}${git::params::gt_gitweb_spath}"],
+      File["${gitolite::params::gt_gitweb_root}${gitolite::params::gt_gitweb_spath}"],
   }
 
   # Flag modifier to allow user to choose whether to use
@@ -112,10 +112,10 @@ class git::server::config(
       } else {
         file { $write_apache_conf_to:
           ensure  => file,
-          content => template('git/gitweb-apache-vhost.conf.erb'),
+          content => template('gitolite/gitweb-apache-vhost.conf.erb'),
           notify  => $apache_notify,
           require => [ File['/etc/gitweb.conf'],
-                        File["${git::params::gt_httpd_conf_dir}/git.conf"] ],
+                        File["${gitolite::params::gt_httpd_conf_dir}/git.conf"] ],
         }
       }
     }
@@ -123,41 +123,41 @@ class git::server::config(
       # By default, use the puppetlabs-apache module to manage Apache
       apache::vhost { $vhost:
         port     => '80',
-        docroot  => $git::params::gt_repo_dir,
+        docroot  => $gitolite::params::gt_repo_dir,
         ssl      => false,
-        template => 'git/gitweb-apache-vhost.conf.erb',
+        template => 'gitolite/gitweb-apache-vhost.conf.erb',
         priority => '99',
         require  => [ File['/etc/gitweb.conf'],
-                      File["${git::params::gt_httpd_conf_dir}/git.conf"] ],
+                      File["${gitolite::params::gt_httpd_conf_dir}/git.conf"] ],
       }
     }
   }
 
   # Gitolite Configuration
-  file { "${git::params::gt_repo_base}/.bash_history":
+  file { "${gitolite::params::gt_repo_base}/.bash_history":
     ensure => 'absent',
   }
   file { 'gitolite-key':
     ensure  => file,
-    path    => "${git::params::gt_repo_base}/gitolite.pub",
+    path    => "${gitolite::params::gt_repo_base}/gitolite.pub",
     content => $ssh_key,
   }
   exec { 'install-gitolite':
-    command     => "gl-setup ${git::params::gt_repo_base}/gitolite.pub",
-    creates     => "${git::params::gt_repo_base}/projects.list",
-    cwd         => $git::params::gt_repo_base,
-    user        => $git::params::gt_uid,
-    environment => "HOME=${git::params::gt_repo_base}",
+    command     => "gl-setup ${gitolite::params::gt_repo_base}/gitolite.pub",
+    creates     => "${gitolite::params::gt_repo_base}/projects.list",
+    cwd         => $gitolite::params::gt_repo_base,
+    user        => $gitolite::params::gt_uid,
+    environment => "HOME=${gitolite::params::gt_repo_base}",
     require     => File['gitolite-key'],
   }
-  file { "${git::params::gt_repo_base}/projects.list":
+  file { "${gitolite::params::gt_repo_base}/projects.list":
     ensure  => file,
     mode    => '0600',
     require => Exec['install-gitolite'],
   }
   file { 'gitolite-config':
-    path    => "${git::params::gt_repo_base}/.gitolite.rc",
-    content => template('git/gitolite.rc.erb'),
+    path    => "${gitolite::params::gt_repo_base}/.gitolite.rc",
+    content => template('gitolite/gitolite.rc.erb'),
     before  => Exec['install-gitolite'],
   }
 }

--- a/manifests/server/package.pp
+++ b/manifests/server/package.pp
@@ -1,4 +1,4 @@
-# Class: git::server::package
+# Class: gitolite::server::package
 #
 # Description
 #  This class is designed to install Git server packages
@@ -14,8 +14,8 @@
 #
 # Sample Usage:
 #   This method should not be called directly.
-class git::server::package {
-  package { $git::params::gt_server_package:
+class gitolite::server::package {
+  package { $gitolite::params::gt_server_package:
     ensure => 'present',
   }
 }


### PR DESCRIPTION
Due to the nature of this module being implementation-specific for instantiating a gitolite server, this module would more aptly be named `gitolite` instead of `git`. Through roles or other abstractions for "git servers", this module would be included as the technological implementation to fulfill the higher need.

So I think that the name of `gitolite` would more accurately represent this module, and be more recognizable when searching the Forge.
