### PR TITLE
Make `manage_apache` parameter default false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,10 +47,11 @@
 #
 #  Manage Apache:
 #   class { 'gitolite':
-#    server    => 'true',
-#    site_name => 'Frymanet.com Git Repository',
-#    ssh_key   => 'ssh-rsa AAAA....',
-#    vhost     => 'git.frymanet.com',
+#    server        => 'true',
+#    site_name     => 'Frymanet.com Git Repository',
+#    ssh_key       => 'ssh-rsa AAAA....',
+#    vhost         => 'git.frymanet.com',
+#    manage_apache => true,
 #  }
 #
 #  Use and External Apache Module:
@@ -61,12 +62,12 @@
 #    vhost                => 'git.frymanet.com',
 #    write_apache_conf_to => '/opt/git/git-apache.conf',
 #    apache_notify        => Service['apache2'],
+#    manage_apache        => true,
 #  }
 #
 #  Do not manage Apache:
 #   class { 'gitolite':
 #    server               => 'true',
-#    manage_apache        => 'false',
 #    site_name            => 'Frymanet.com Git Repository',
 #    ssh_key              => 'ssh-rsa AAAA....',
 #  }
@@ -77,7 +78,7 @@ class gitolite(
   $server               = false,
   $site_name            = '',
   $vhost                = '',
-  $manage_apache        = true,
+  $manage_apache        = false,
   $apache_notify        = '',
   $write_apache_conf_to = '',
   $ssh_key              = ''


### PR DESCRIPTION
A gitolite server is essentially gitolite, and adding apache+gitweb on
top would be an additional feature. I think the additional feature
should not be enabled by default, and consumers of this module may
enable as desired.
