### PR TITLE
Add validation for true/false parameters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,7 @@ _Apache Module_
 *Setup the initial Gitolite Admin keys and bootstrap* 
 <pre>
    class { 'gitolite':
-    server    => 'true',
+    server    => true,
     site_name => 'Frymanet.com Git Repository',
     ssh_key   => 'ssh-rsa AAAA....',
     vhost     => 'git.frymanet.com',
@@ -28,7 +28,7 @@ _Apache Module_
 *Setup the initial Gitolite Admin keys and bootstrap using an external apache module* 
 <pre>
    class { 'gitolite':
-    server               => 'true',
+    server               => true,
     site_name            => 'Frymanet.com Git Repository',
     ssh_key              => 'ssh-rsa AAAA....',
     vhost                => 'git.frymanet.com',
@@ -40,8 +40,8 @@ _Apache Module_
 *Setup the initial Gitolite Admin keys and bootstrap, but don't manage apache*
 <pre> 
    class { 'gitolite':
-    server               => 'true',
-    manage_apache        => 'false',
+    server               => true,
+    manage_apache        => false,
     site_name            => 'Frymanet.com Git Repository',
     ssh_key              => 'ssh-rsa AAAA....',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,7 @@
 #
 #  Manage Apache:
 #   class { 'gitolite':
-#    server        => 'true',
+#    server        => true,
 #    site_name     => 'Frymanet.com Git Repository',
 #    ssh_key       => 'ssh-rsa AAAA....',
 #    vhost         => 'git.frymanet.com',
@@ -58,7 +58,7 @@
 #
 #  Use and External Apache Module:
 #   class { 'gitolite':
-#    server               => 'true',
+#    server               => true,
 #    site_name            => 'Frymanet.com Git Repository',
 #    ssh_key              => 'ssh-rsa AAAA....',
 #    vhost                => 'git.frymanet.com',
@@ -69,7 +69,7 @@
 #
 #  Do not manage Apache:
 #   class { 'gitolite':
-#    server               => 'true',
+#    server               => true,
 #    site_name            => 'Frymanet.com Git Repository',
 #    ssh_key              => 'ssh-rsa AAAA....',
 #  }
@@ -89,6 +89,7 @@ class gitolite(
 ) {
   include stdlib
   include gitolite::params
+  validate_bool($server)
 
   anchor { 'gitolite::begin': }
   -> class  { 'gitolite::client': }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -59,7 +59,7 @@
 #
 #  Do not manage Apache:
 #   class { 'gitolite::server':
-#    manage_apache        => 'false',
+#    manage_apache        => false,
 #    site_name            => 'Frymanet.com Git Repository',
 #    ssh_key              => 'ssh-rsa AAAA....',
 #  }
@@ -68,7 +68,7 @@ class gitolite::server(
   $ssh_key,
   $site_name            = '',
   $vhost                = '',
-  $manage_apache        = '',
+  $manage_apache        = false,
   $apache_notify        = '',
   $write_apache_conf_to = '',
   $wildrepos            = false

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -42,6 +42,9 @@ class gitolite::server::config(
   $write_apache_conf_to,
   $wildrepos
 ) {
+  validate_bool($wildrepos)
+  validate_bool($manage_apache)
+
   File {
     owner => $gitolite::params::gt_uid,
     group => $gitolite::params::gt_gid,

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -2,7 +2,7 @@
 #
 #  Manage Apache:
 class { 'gitolite':
-  server    => 'true',
+  server    => true,
   site_name => 'Frymanet.com Git Repository',
   ssh_key   => 'ssh-rsa AAAA....',
   vhost     => 'git.frymanet.com',
@@ -10,7 +10,7 @@ class { 'gitolite':
 #
 #  Use and External Apache Module:
 class { 'gitolite':
-  server               => 'true',
+  server               => true,
   site_name            => 'Frymanet.com Git Repository',
   ssh_key              => 'ssh-rsa AAAA....',
   vhost                => 'git.frymanet.com',
@@ -20,8 +20,8 @@ class { 'gitolite':
 #
 #  Do not manage Apache:
 class { 'gitolite':
-  server        => 'true',
-  manage_apache => 'false',
+  server        => true,
+  manage_apache => false,
   site_name     => 'Frymanet.com Git Repository',
   ssh_key       => 'ssh-rsa AAAA....',
 }


### PR DESCRIPTION
If parameters which are expected to be true/false are not a boolean
type, such as passing a quoted 'true' to the `server` parameter of
`Class['gitolite']` then the gitolite module will silently do nothing.
This commit corrects that behaviour.
