### PR TITLE
Added support for setting GIT_CONFIG_KEYS in rc

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,9 @@
 #  $repo_specific_hooks: enable repo-specific hooks in gitolite configuration
 #  $local_code: path to a directory to add or override gitolite programs
 #               (see http://gitolite.com/gitolite/cust.html#localcode)
+#  $git_config_keys: Config keys to allow in gitolite.conf. Set to '.*' to allow
+#                    all keys. Needed for gitolite local hooks (see
+#                    http://gitolite.com/gitolite/gitolite.html#rc)
 #
 #
 # Actions:
@@ -94,7 +97,8 @@ class gitolite(
   $wildrepos            = false,
   $grouplist_pgm        = undef,
   $repo_specific_hooks  = false,
-  $local_code           = undef
+  $local_code           = undef,
+  $git_config_keys      = '',
 ) {
   include stdlib
   include gitolite::params

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jfryman-gitolite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "James Fryman",
   "summary": "Install and bootstrap a Gitolite Server instance. Includes Gitolite and GitWeb as a viewer.",
   "license": "Apache-2.0",

--- a/templates/gitolite.rc.erb
+++ b/templates/gitolite.rc.erb
@@ -1,13 +1,13 @@
 %RC = (
     UMASK                           =>  0027,
-    GIT_CONFIG_KEYS                 =>  '',
+    GIT_CONFIG_KEYS                 =>  '<%= @git_config_keys %>',
     LOG_EXTRA                       =>  1,
     ROLES => {
         READERS                     =>  1,
         WRITERS                     =>  1,
     },<% if @grouplist_pgm %>
     GROUPLIST_PGM                   => '<%= @grouplist_pgm %>',<% end %><% if @local_code %>
-    LOCAL_CODE                      => '<%= @local_code %>',<% end %>
+    LOCAL_CODE                      => "<%= @local_code %>",<% end %>
     ENABLE => [
 
             'help',


### PR DESCRIPTION
Also changed quotes for LOCAL_CODE from single to double quotes, which is needed so gitolite can expand the `$ENV{USER}` variable.

Note that this needs to be in single quotes when using the class, as it'll be expanded by puppet otherwise.
